### PR TITLE
People Picker component creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mui-spfx-controls",
-  "version": "0.0.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mui-spfx-controls",
-      "version": "0.0.1",
+      "version": "0.5.0",
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mui-spfx-controls",
+  "description": "SPFx component library with MUI",
   "version": "0.5.0",
   "engines": {
     "node": ">=16.13.0 <17.0.0 || >=18.17.1 <19.0.0"

--- a/src/components/PeoplePicker.tsx
+++ b/src/components/PeoplePicker.tsx
@@ -119,8 +119,8 @@ export const PeoplePicker: FC<IPeoplePickerProps> = ({
       renderInput={(params) => (
         <TextField
           {...params}
-          color={color}
           variant={variant}
+          color={color}
           error={error !== null ? true : false}
           helperText={error ? "Something went wrong" : ""}
           label={label}

--- a/src/components/PeoplePicker.tsx
+++ b/src/components/PeoplePicker.tsx
@@ -95,6 +95,7 @@ export const PeoplePicker: FC<IPeoplePickerProps> = ({
       onInputChange={(event, newValue) => setQuery(newValue)}
       renderTags={(users, getTagProps) => {
         return users.map((user, index) => (
+          // eslint-disable-next-line
           <Chip
             {...getTagProps({ index })}
             avatar={<Avatar src={user.Image} />}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-// A file is required to be in the root of the /src directory by the TypeScript compiler
+export * from "./components";
+export * from "./types";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,2 @@
 export * from "./generateImageUrl";
 export * from "./handleDuplicates";
-export * from "./validateEmail";

--- a/src/utils/validateEmail.ts
+++ b/src/utils/validateEmail.ts
@@ -1,7 +1,0 @@
-const validateEmail = (email: string): boolean => {
-  return !!email.match(
-    /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
-  );
-};
-
-export { validateEmail };

--- a/src/webparts/peoplePicker/IPeoplePickerDisplayProps.ts
+++ b/src/webparts/peoplePicker/IPeoplePickerDisplayProps.ts
@@ -1,7 +1,0 @@
-import { WebPartContext } from "@microsoft/sp-webpart-base";
-
-interface IPeoplePickerDisplayProps {
-  context: WebPartContext;
-}
-
-export type { IPeoplePickerDisplayProps };

--- a/src/webparts/peoplePicker/PeoplePickerDisplay.tsx
+++ b/src/webparts/peoplePicker/PeoplePickerDisplay.tsx
@@ -2,17 +2,27 @@ import { ThemeProvider } from "@mui/material";
 import * as React from "react";
 import { PeoplePicker } from "../../components";
 import { theme } from "../../config";
-import { IPeoplePickerDisplayProps } from "./IPeoplePickerDisplayProps";
+import { IPeoplePickerProps } from "../../types";
 
-const PeoplePickerDisplay: React.FC<IPeoplePickerDisplayProps> = ({
+const PeoplePickerDisplay: React.FC<IPeoplePickerProps> = ({
   context,
+  label,
+  size,
+  searchSuggestionLimit,
+  variant,
+  disabled,
+  color,
 }) => {
   return (
     <ThemeProvider theme={theme}>
       <PeoplePicker
-        label="People"
+        label={label}
         context={context}
-        searchSuggestionLimit={20}
+        size={size}
+        variant={variant}
+        color={color}
+        disabled={disabled}
+        searchSuggestionLimit={searchSuggestionLimit}
       />
     </ThemeProvider>
   );

--- a/src/webparts/peoplePicker/PeoplePickerWebPart.manifest.json
+++ b/src/webparts/peoplePicker/PeoplePickerWebPart.manifest.json
@@ -3,26 +3,33 @@
   "id": "1c927782-1a6d-440c-bb97-5557d5698b1c",
   "alias": "PeoplePickerWebPart",
   "componentType": "WebPart",
-
-  // The "*" signifies that the version should be taken from the package.json
   "version": "*",
   "manifestVersion": 2,
-
-  // If true, the component can only be installed on sites where Custom Script is allowed.
-  // Components that allow authors to embed arbitrary script code should set this to true.
-  // https://support.office.com/en-us/article/Turn-scripting-capabilities-on-or-off-1f2c515f-5d7e-448a-9fd7-835da935584f
   "requiresCustomScript": false,
-  "supportedHosts": ["SharePointWebPart", "TeamsPersonalApp", "TeamsTab", "SharePointFullPage"],
+  "supportedHosts": [
+    "SharePointWebPart",
+    "TeamsPersonalApp",
+    "TeamsTab",
+    "SharePointFullPage"
+  ],
   "supportsThemeVariants": true,
-
-  "preconfiguredEntries": [{
-    "groupId": "5c03119e-3074-46fd-976b-c60198311f70", // Advanced
-    "group": { "default": "Advanced" },
-    "title": { "default": "PeoplePicker" },
-    "description": { "default": "PeoplePicker description" },
-    "officeFabricIconFontName": "Page",
-    "properties": {
-      "description": "PeoplePicker"
+  "preconfiguredEntries": [
+    {
+      "groupId": "5c03119e-3074-46fd-976b-c60198311f70",
+      "group": { "default": "Advanced" },
+      "title": {
+        "default": "People Picker"
+      },
+      "description": {
+        "default": "SharePoint Framework component and webpart library built using Material-UI"
+      },
+      "officeFabricIconFontName": "People",
+      "properties": {
+        "label": "People",
+        "size": "medium",
+        "color": "primary",
+        "searchSuggestionsLimit": 10
+      }
     }
-  }]
+  ]
 }

--- a/src/webparts/peoplePicker/PeoplePickerWebPart.ts
+++ b/src/webparts/peoplePicker/PeoplePickerWebPart.ts
@@ -1,25 +1,35 @@
 import { Version } from "@microsoft/sp-core-library";
 import {
+  PropertyPaneChoiceGroup,
+  PropertyPaneDropdown,
   PropertyPaneTextField,
+  PropertyPaneToggle,
   type IPropertyPaneConfiguration,
 } from "@microsoft/sp-property-pane";
 import { BaseClientSideWebPart } from "@microsoft/sp-webpart-base";
 import * as strings from "PeoplePickerWebPartStrings";
 import * as React from "react";
 import * as ReactDom from "react-dom";
-import { IPeoplePickerDisplayProps } from "./IPeoplePickerDisplayProps";
+import { IPeoplePickerProps } from "../../types";
 import PeoplePickerDisplay from "./PeoplePickerDisplay";
 
-export interface IPeoplePickerWebPartProps {
+export interface IPeoplePickerWebPartProps extends IPeoplePickerProps {
   description: string;
 }
 
 export default class PeoplePickerWebPart extends BaseClientSideWebPart<IPeoplePickerWebPartProps> {
   public render(): void {
-    const element: React.ReactElement<IPeoplePickerDisplayProps> =
-      React.createElement(PeoplePickerDisplay, {
+    const element: React.ReactElement<IPeoplePickerProps> = React.createElement(
+      PeoplePickerDisplay,
+      {
         context: this.context,
-      });
+        label: this.properties.label,
+        size: this.properties.size,
+        disabled: this.properties.disabled,
+        variant: this.properties.variant,
+        color: this.properties.color,
+      }
+    );
 
     ReactDom.render(element, this.domElement);
   }
@@ -47,8 +57,72 @@ export default class PeoplePickerWebPart extends BaseClientSideWebPart<IPeoplePi
             {
               groupName: strings.BasicGroupName,
               groupFields: [
-                PropertyPaneTextField("description", {
-                  label: strings.DescriptionFieldLabel,
+                PropertyPaneTextField("label", {
+                  label: strings.LabelFieldLabel,
+                }),
+                PropertyPaneChoiceGroup("size", {
+                  label: strings.SizeFieldLabel,
+                  options: [
+                    {
+                      key: "small",
+                      text: "small",
+                    },
+                    {
+                      key: "medium",
+                      text: "medium",
+                    },
+                  ],
+                }),
+                PropertyPaneToggle("disabled", {
+                  label: strings.DisabledFieldLabel,
+                }),
+                PropertyPaneDropdown("variant", {
+                  label: strings.VariantFieldLabel,
+                  selectedKey: "outlined",
+                  options: [
+                    {
+                      key: "outlined",
+                      text: "outlined",
+                    },
+                    {
+                      key: "standard",
+                      text: "standard",
+                    },
+                    {
+                      key: "filled",
+                      text: "filled",
+                    },
+                  ],
+                }),
+                PropertyPaneDropdown("color", {
+                  label: strings.ColorFieldLabel,
+                  selectedKey: "primary",
+                  options: [
+                    {
+                      key: "primary",
+                      text: "primary",
+                    },
+                    {
+                      key: "secondary",
+                      text: "secondary",
+                    },
+                    {
+                      key: "info",
+                      text: "info",
+                    },
+                    {
+                      key: "success",
+                      text: "success",
+                    },
+                    {
+                      key: "warning",
+                      text: "warning",
+                    },
+                    {
+                      key: "error",
+                      text: "error",
+                    },
+                  ],
                 }),
               ],
             },

--- a/src/webparts/peoplePicker/loc/en-us.js
+++ b/src/webparts/peoplePicker/loc/en-us.js
@@ -1,16 +1,11 @@
-define([], function() {
+define([], function () {
   return {
-    "PropertyPaneDescription": "Description",
-    "BasicGroupName": "Group Name",
-    "DescriptionFieldLabel": "Description Field",
-    "AppLocalEnvironmentSharePoint": "The app is running on your local environment as SharePoint web part",
-    "AppLocalEnvironmentTeams": "The app is running on your local environment as Microsoft Teams app",
-    "AppLocalEnvironmentOffice": "The app is running on your local environment in office.com",
-    "AppLocalEnvironmentOutlook": "The app is running on your local environment in Outlook",
-    "AppSharePointEnvironment": "The app is running on SharePoint page",
-    "AppTeamsTabEnvironment": "The app is running in Microsoft Teams",
-    "AppOfficeEnvironment": "The app is running in office.com",
-    "AppOutlookEnvironment": "The app is running in Outlook",
-    "UnknownEnvironment": "The app is running in an unknown environment"
-  }
+    PropertyPaneDescription: "People Picker",
+    BasicGroupName: "Properties",
+    LabelFieldLabel: "Label",
+    SizeFieldLabel: "Size",
+    DisabledFieldLabel: "Disabled",
+    VariantFieldLabel: "Variant",
+    ColorFieldLabel: "Color",
+  };
 });

--- a/src/webparts/peoplePicker/loc/en-us.js
+++ b/src/webparts/peoplePicker/loc/en-us.js
@@ -1,6 +1,7 @@
 define([], function () {
   return {
-    PropertyPaneDescription: "People Picker",
+    PropertyPaneDescription:
+      "SharePoint Framework component and webpart library built using Material-UI",
     BasicGroupName: "Properties",
     LabelFieldLabel: "Label",
     SizeFieldLabel: "Size",

--- a/src/webparts/peoplePicker/loc/mystrings.d.ts
+++ b/src/webparts/peoplePicker/loc/mystrings.d.ts
@@ -1,19 +1,14 @@
 declare interface IPeoplePickerWebPartStrings {
   PropertyPaneDescription: string;
   BasicGroupName: string;
-  DescriptionFieldLabel: string;
-  AppLocalEnvironmentSharePoint: string;
-  AppLocalEnvironmentTeams: string;
-  AppLocalEnvironmentOffice: string;
-  AppLocalEnvironmentOutlook: string;
-  AppSharePointEnvironment: string;
-  AppTeamsTabEnvironment: string;
-  AppOfficeEnvironment: string;
-  AppOutlookEnvironment: string;
-  UnknownEnvironment: string;
+  LabelFieldLabel: string;
+  SizeFieldLabel: string;
+  DisabledFieldLabel: string;
+  VariantFieldLabel: string;
+  ColorFieldLabel: string;
 }
 
-declare module 'PeoplePickerWebPartStrings' {
+declare module "PeoplePickerWebPartStrings" {
   const strings: IPeoplePickerWebPartStrings;
   export = strings;
 }


### PR DESCRIPTION
## PeoplePicker

People Picker component with MUI library integration

#### Props

- context (required): SP
- label (required): Textfield label
- onSelectionChange (optional): Get selection value updates
- searchSuggestionLimit (optional): number of suggestions to provide
- variant (optional): Textfield variant ('standard', 'outlined', 'filled')
- color (optional): Button color, e.g., "primary" or "secondary"
- disabled (optional): Is component disabled
- size (optional): Size of component
- LoadingComponent (optional): A loading component
- styles (optional): Styles to apply
- sx (optional): MUI's sx prop

```JSX
import * as React from 'react';
import { BaseClientSideWebPart } from '@microsoft/sp-webpart-base';
import { ThemeProvider } from '@mui/material';
import { PeoplePicker } from 'mui-spfx-controls';
import { theme } from '/path/to/theme';

export default class PeoplePickerWebPart extends BaseClientWebPart {
  public render(): React.ReactElement<any> {
    return (
      <ThemeProvider theme={theme}>
        <PeoplePicker context={this.context} label="Search" color="primary" variant="outlined">
      </ThemeProvider>
    );
  }
}
```